### PR TITLE
Create subject montages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 img
+montages
 temp.js
 npm-debug.log
 bin/

--- a/README.md
+++ b/README.md
@@ -29,7 +29,15 @@ Params are: w x h dimensions.
 + http://localhost:3000/resize_crop?w=500&h=600&u=panoptes-uploads.zooniverse.org/production/subject_location/90a3b642-55e2-4583-a4fb-2f0abeb5b285.jpeg
 
 ## Require
-Requires imagemagick CLI tools to be installed.
+Requires [GraphicsMagick](http://www.graphicsmagick.org/) **and** (for now) [ImageMagick](http://imagemagick.org/) CLI tools to be installed:
+
+Debian/Ubuntu:
+
+`apt-get install imagemagick graphicsmagick`
+
+OSX:
+
+`brew install imagemagick` or `port install ImageMagick`
 
 ## Install and run
 ```js

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Params are: w x h dimensions.
 ## /montage route
 Tile several images together to create a multi-image subject image. Requires at least two images
 
-Params are: w for tile width.
+Params are: w for tile width, mw for max desired width (for the final image)
 
 + http://localhost:3000/montage?u=panoptes-uploads.zooniverse.org/production/subject_location/90a3b642-55e2-4583-a4fb-2f0abeb5b285.jpeg&u=panoptes-uploads.zooniverse.org/production/subject_location/90a3b642-55e2-4583-a4fb-2f0abeb5b285.jpeg
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,13 @@ Params are: w x h dimensions.
 
 + http://localhost:3000/resize_crop?w=500&h=600&u=panoptes-uploads.zooniverse.org/production/subject_location/90a3b642-55e2-4583-a4fb-2f0abeb5b285.jpeg
 
+## /montage route
+Tile several images together to create a multi-image subject image. Requires at least two images
+
+Params are: w for tile width.
+
++ http://localhost:3000/montage?u=panoptes-uploads.zooniverse.org/production/subject_location/90a3b642-55e2-4583-a4fb-2f0abeb5b285.jpeg&u=panoptes-uploads.zooniverse.org/production/subject_location/90a3b642-55e2-4583-a4fb-2f0abeb5b285.jpeg
+
 ## Require
 Requires [GraphicsMagick](http://www.graphicsmagick.org/) **and** (for now) [ImageMagick](http://imagemagick.org/) CLI tools to be installed:
 

--- a/docker/static_crop_cron
+++ b/docker/static_crop_cron
@@ -1,1 +1,1 @@
-00 * * * * root /usr/sbin/tmpreaper -v 1d /node_app/img >> /var/log/cron.log 2>&1
+00 * * * * root /usr/sbin/tmpreaper -v 1d /node_app/img /node_app/montages >> /var/log/cron.log 2>&1

--- a/lib/montage.js
+++ b/lib/montage.js
@@ -1,0 +1,38 @@
+var Img = require('./image')
+  , gm = require('gm')
+  , util = require('util')
+  , fs = require('fs')
+  ;
+
+/**
+ * Montage creator - arranges images in a layout/grid
+ * @class
+ * @param {Array<image>} imgs List of images from which to construct the montage
+ */
+var Montage = function (imgs) {
+  this.imgs = imgs;
+};
+
+/**
+ * Builds the montage
+ * @callback done Called with the path to the montaged file
+ */
+Montage.prototype.construct = function (done) {
+  var outfile = process.cwd()+'/outfile.'+this.imgs[0].extension;
+  imageFileNames = this.imgs.map(function (img) {
+    return img.url;
+  });
+  // Start with the first image...
+  var g = gm(imageFileNames[0]);
+  // ...then add the rest
+  imageFileNames.slice(1).forEach(function (imgFileName) {
+    g.montage(imgFileName);
+  });
+  // Write file (@todo figure out why streams don't work with montage)
+  g.write(outfile, function (err) {
+    done(err, outfile);
+  });
+};
+
+// Export class
+module.exports = Montage;

--- a/lib/montage.js
+++ b/lib/montage.js
@@ -10,33 +10,51 @@ var Img = require('./image')
  * @class
  * @param {Array<image>} imgs List of images from which to construct the montage
  * @param {Number} [tileSize=120] Pixel width for each tile
+ * @param {Number} [maxWidth=0] Maximum pixel width for final image. Will determine the layout used by the montage.
  */
-var Montage = function (imgs, tileSize) {
+var Montage = function (imgs, tileSize, maxWidth) {
   this.imgs = imgs;
   this.tileSize = typeof tileSize !== 'undefined' ? tileSize : 120;
+  this.maxWidth = maxWidth;
 };
 
-/**
- * Builds the montage
- * @callback done Called with the path to the montaged file
- */
-Montage.prototype.construct = function (done) {
-  imageFileNames = this.imgs.map(function (img) {
-    return img.url;
-  });
-  var imagesFileNamesHashed = crypto.createHash('md5').update(imageFileNames.join('__')).digest('hex');
-  var outfile = util.format('%s/montages/%s.%s', process.cwd(), imagesFileNamesHashed, this.imgs[0].extension);
-  // Start with the first image...
-  var g = gm(imageFileNames[0]);
-  // ...then add the rest
-  imageFileNames.slice(1).forEach(function (imgFileName) {
-    g.montage(imgFileName);
-  });
-  g.geometry(this.tileSize+'>');
-  // Write file (@todo figure out why streams don't work with montage)
-  g.write(outfile, function (err) {
-    done(err, outfile);
-  });
+Montage.prototype = {
+
+  /**
+   * Grid layout to use
+   * @type {String}
+   */
+  get layout () {
+    var numCols = Math.floor(this.maxWidth / this.tileSize);
+    var numRows = Math.ceil(this.imgs.length / numCols);
+    return util.format('%sx%s', numCols, numRows);
+  },
+
+  /**
+   * Builds the montage
+   * @public
+   * @callback done Called with the path to the montaged file
+   */
+  construct: function (done) {
+    imageFileNames = this.imgs.map(function (img) {
+      return img.url;
+    });
+    var imagesFileNamesHashed = crypto.createHash('md5').update(imageFileNames.join('__')).digest('hex');
+    var outfile = util.format('%s/montages/%s.%s', process.cwd(), imagesFileNamesHashed, this.imgs[0].extension);
+    // Start with the first image...
+    var g = gm(imageFileNames[0]);
+    // ...then add the rest
+    imageFileNames.slice(1).forEach(function (imgFileName) {
+      g.montage(imgFileName);
+    });
+    g.geometry(this.tileSize+'>');
+    // If max width set, apply layout to satisfy
+    g.tile(this.layout);
+    // Write file (@todo figure out why streams don't work with montage)
+    g.write(outfile, function (err) {
+      done(err, outfile);
+    });
+  }
 };
 
 // Export class

--- a/lib/montage.js
+++ b/lib/montage.js
@@ -2,6 +2,7 @@ var Img = require('./image')
   , gm = require('gm')
   , util = require('util')
   , fs = require('fs')
+  , crypto = require('crypto')
   ;
 
 /**
@@ -18,10 +19,11 @@ var Montage = function (imgs) {
  * @callback done Called with the path to the montaged file
  */
 Montage.prototype.construct = function (done) {
-  var outfile = process.cwd()+'/outfile.'+this.imgs[0].extension;
   imageFileNames = this.imgs.map(function (img) {
     return img.url;
   });
+  var imagesFileNamesHashed = crypto.createHash('md5').update(imageFileNames.join('__')).digest('hex');
+  var outfile = util.format('%s/montages/%s.%s', process.cwd(), imagesFileNamesHashed, this.imgs[0].extension);
   // Start with the first image...
   var g = gm(imageFileNames[0]);
   // ...then add the rest

--- a/lib/montage.js
+++ b/lib/montage.js
@@ -9,9 +9,11 @@ var Img = require('./image')
  * Montage creator - arranges images in a layout/grid
  * @class
  * @param {Array<image>} imgs List of images from which to construct the montage
+ * @param {Number} [tileSize=120] Pixel width for each tile
  */
-var Montage = function (imgs) {
+var Montage = function (imgs, tileSize) {
   this.imgs = imgs;
+  this.tileSize = typeof tileSize !== 'undefined' ? tileSize : 120;
 };
 
 /**
@@ -30,6 +32,7 @@ Montage.prototype.construct = function (done) {
   imageFileNames.slice(1).forEach(function (imgFileName) {
     g.montage(imgFileName);
   });
+  g.geometry(this.tileSize+'>')
   // Write file (@todo figure out why streams don't work with montage)
   g.write(outfile, function (err) {
     done(err, outfile);

--- a/lib/montage.js
+++ b/lib/montage.js
@@ -1,5 +1,5 @@
 var Img = require('./image')
-  , gm = require('gm')
+  , gm = require('gm').subClass({ imageMagick: true })
   , util = require('util')
   , fs = require('fs')
   , crypto = require('crypto')

--- a/lib/montage.js
+++ b/lib/montage.js
@@ -32,7 +32,7 @@ Montage.prototype.construct = function (done) {
   imageFileNames.slice(1).forEach(function (imgFileName) {
     g.montage(imgFileName);
   });
-  g.geometry(this.tileSize+'>')
+  g.geometry(this.tileSize+'>');
   // Write file (@todo figure out why streams don't work with montage)
   g.write(outfile, function (err) {
     done(err, outfile);

--- a/package.json
+++ b/package.json
@@ -8,9 +8,10 @@
     "node": ">= v0.8.x"
   },
   "dependencies": {
+    "async": "^1.5.0",
     "express": "^4.13.3",
+    "gm": "^1.21.1",
     "imagemagick": "^0.1.3",
-    "gm": "^1.20.0",
     "morgan": "^1.6.1"
   },
   "main": "server"

--- a/server.js
+++ b/server.js
@@ -112,7 +112,8 @@ app.get('/crop', function(req, res, next){
  * Montage route. Takes multiple images and combines them into a pleasing grid/tile layout
  */
 app.get('/montage', function(req, res, next){
-	u = req.query.u;
+	// Get url(s)
+	var u = req.query.u;
 	if (!Array.isArray(u)) {
 		return next(new Error('Please specify at least two images'));
 	}

--- a/server.js
+++ b/server.js
@@ -123,7 +123,7 @@ app.get('/montage', function(req, res, next){
 		new Img(static_host + u,img_path).load(done);
 	}, function (err, images) {
 		if (err) next(new Error(err));
-		var montage = new Montage(images);
+		var montage = new Montage(images, req.query.w);
 		montage.construct(function (err, outfile) {
 			if (err) next(new Error(err));
 			res.sendFile(outfile);

--- a/server.js
+++ b/server.js
@@ -123,7 +123,7 @@ app.get('/montage', function(req, res, next){
 		new Img(static_host + u,img_path).load(done);
 	}, function (err, images) {
 		if (err) next(new Error(err));
-		var montage = new Montage(images, req.query.w);
+		var montage = new Montage(images, req.query.w, req.query.mw);
 		montage.construct(function (err, outfile) {
 			if (err) next(new Error(err));
 			res.sendFile(outfile);


### PR DESCRIPTION
As mentioned in https://github.com/zooniverse/static-crop/issues/2#issuecomment-155115099 this is complete with the caveat that it writes the final montage file to disk before sending down to the client; ideally we'd just stream it down but the `gm` module's `montage` method doesn't seem to play nicely with streams.
