### PR TITLE
Add Straight URL Route for Crop

### DIFF
--- a/server.js
+++ b/server.js
@@ -80,6 +80,34 @@ app.get('/resize_crop', function(req, res, next){
 	});
 });
 
+app.get('/crop/:w/:h/:x/:y/:u', function(req, res, next){
+	var u =  decodeURIComponent(req.params.u) // URL
+		, w =  req.params.w // width
+		, h =  req.params.h // height
+		, x =  req.params.x // x-offset
+		, y =  req.params.y // y-offset
+		;
+	if (!u || !w || !h || !x || !y) res.send(400, {error: crop_message});
+
+	var img = new Img(static_host + u,img_path).load(function(err,im) {
+		if (err) res.status(500).send({ error: err })
+		else {
+			if (app.get("debug")) {
+				console.log("\nCrop image:");
+				console.log(im);
+			}
+			res.writeHead(200, {"Content-Type": "image/" + im.extension});
+			gm(im.destHashed)
+				.crop(w, h, x, y)
+				.stream(function streamOut (err, stdout, stderr) {
+					if (err) res.status(500).send({ error: err })
+					stdout.pipe(res);
+					stdout.on('error', next);
+				});
+		}
+	});
+});
+
 app.get('/crop', function(req, res, next){
 	var u = req.query.u // URL
 		, w = req.query.w // width


### PR DESCRIPTION
Another route was created for "crop" in order to accept a straight URL rather than query params. This change was made in order to pass the call to another external API query string.
